### PR TITLE
make platform calls more robust

### DIFF
--- a/lib/thegamesdb.rb
+++ b/lib/thegamesdb.rb
@@ -61,15 +61,21 @@ module Gamesdb
       platform[node.value.to_sym] = node.text
     end
     if data.Images
-      platform[:Images] = {
-        boxart: {
-          url: data.Images.boxart.text,
-          width: data.Images.boxart.attributes[:width],
-          height: data.Images.boxart.attributes[:height]
-        },
-        console_art: data.Images.consoleart.text,
-        controller_image: data.Images.controllerart.text
-      }
+      boxart = data.Images.boxart rescue nil
+      platform[:Images] = {}
+      if boxart
+        platform[:Images][:boxart] = {
+          url: boxart.text,
+          width: boxart.attributes[:width],
+          height: boxart.attributes[:height]
+        }
+      end
+      if consoleart = data.Images.consoleart rescue nil
+        platform[:Images][:console_art] = consoleart.text
+      end
+      if controllerart = data.Images.controllerart rescue nil
+        platform[:Images][:controller_image] = controllerart.text
+      end
     end
     platform
   end

--- a/lib/thegamesdb.rb
+++ b/lib/thegamesdb.rb
@@ -178,7 +178,7 @@ module Gamesdb
       overview: game.Overview.text, publisher: game.Publisher.text,
       developer: game.Developer.text,
       genres: game.Genres.nodes.map(&:text),
-      platform_id: game.PlatformId,
+      platform_id: game.PlatformId.text,
       # esrb: game.ESRB.text, rating: game.Rating.text,
       images: images
     }

--- a/lib/thegamesdb.rb
+++ b/lib/thegamesdb.rb
@@ -177,7 +177,8 @@ module Gamesdb
       release_date: game.ReleaseDate.text, platform: game.Platform.text,
       overview: game.Overview.text, publisher: game.Publisher.text,
       developer: game.Developer.text,
-      genres: game.Genres.nodes.map(&:text).join(', '),
+      genres: game.Genres.nodes.map(&:text),
+      platform_id: game.PlatformId,
       # esrb: game.ESRB.text, rating: game.Rating.text,
       images: images
     }

--- a/lib/thegamesdb.rb
+++ b/lib/thegamesdb.rb
@@ -172,16 +172,20 @@ module Gamesdb
       key = a.attributes[:side].to_sym
       images[key] = a.text
     end
-    {
+    attributes = {
       id: game.id.text.to_i, title: game.GameTitle.text,
-      release_date: game.ReleaseDate.text, platform: game.Platform.text,
-      overview: game.Overview.text, publisher: game.Publisher.text,
-      developer: game.Developer.text,
-      genres: game.Genres.nodes.map(&:text),
+      platform: game.Platform.text,
       platform_id: game.PlatformId.text,
       # esrb: game.ESRB.text, rating: game.Rating.text,
       images: images
     }
+    attributes[:overview] = game.Overview.text rescue ''
+    attributes[:publisher] = game.Publisher.text rescue ''
+    attributes[:developer] = game.Developer.text rescue ''
+    attributes[:release_date] = game.ReleaseDate.text rescue ''
+    attributes[:genres] = game.Genres.nodes.map(&:text) rescue []
+    attributes[:coop] = game.send('Co-op').text != 'No' rescue false
+    attributes
   end
 
   def self.build_games_list(data)

--- a/test/gamesdb_test.rb
+++ b/test/gamesdb_test.rb
@@ -63,24 +63,67 @@ describe Gamesdb do
   end
 
   describe 'platform' do
-    before do
-      VCR.insert_cassette('platform')
-      @platform = Gamesdb.platform 6
+    describe 'assigning basic info' do
+      before do
+        VCR.insert_cassette('nintendo platform')
+        @platform = Gamesdb.platform 6
+      end
+
+      after do
+        VCR.eject_cassette
+      end
+
+      it 'should return valid platform info' do
+        @platform[:name].must_equal 'Super Nintendo (SNES)'
+        @platform[:overview].must_be_kind_of String
+        @platform[:developer].must_be_kind_of String
+        @platform[:manufacturer].must_equal 'Nintendo'
+        @platform[:cpu].must_be_kind_of String
+        @platform[:memory].must_be_kind_of String
+        @platform[:sound].must_be_kind_of String
+        @platform[:display].must_be_kind_of String
+      end
+
+      it 'should assign images if provided' do
+        images = @platform[:Images]
+        images[:boxart][:url].must_equal "platform/boxart/6-2.jpg"
+        images[:boxart][:width].must_equal "500"
+        images[:boxart][:height].must_equal "750"
+        images[:console_art].must_equal "platform/consoleart/6.png"
+        images[:controller_image].must_equal "platform/controllerart/6.png"
+      end
+
     end
 
-    after do
-      VCR.eject_cassette
-    end
+    describe 'without hardware or images' do
+      before do
+        VCR.insert_cassette('android platform')
+        @platform = Gamesdb.platform 4916
+      end
 
-    it 'should return valid platform info' do
-      @platform[:name].must_equal 'Super Nintendo (SNES)'
-      @platform[:overview].must_be_kind_of String
-      @platform[:developer].must_be_kind_of String
-      @platform[:manufacturer].must_equal 'Nintendo'
-      @platform[:cpu].must_be_kind_of String
-      @platform[:memory].must_be_kind_of String
-      @platform[:sound].must_be_kind_of String
-      @platform[:display].must_be_kind_of String
+      after do
+        VCR.eject_cassette
+      end
+
+      it 'should return valid platform info' do
+        @platform[:name].must_equal 'Android'
+        @platform[:overview].must_be_kind_of String
+        @platform[:developer].must_be_kind_of String
+        @platform[:manufacturer].must_be_nil
+        @platform[:cpu].must_be_nil
+        @platform[:memory].must_be_nil
+        @platform[:sound].must_be_nil
+        @platform[:display].must_be_nil
+      end
+
+      it 'should not fail hard if no images are provided' do
+        images = @platform[:Images]
+        images[:boxart][:url].must_equal "platform/boxart/4916-2.jpg"
+        images[:boxart][:width].must_equal "820"
+        images[:boxart][:height].must_equal "1080"
+        images[:console_art].must_be_nil
+        images[:controller_image].must_be_nil
+      end
     end
   end
 


### PR DESCRIPTION
calling Gamesdb.platform won't throw errors when images are missing.
